### PR TITLE
fix: set correct domain name and TTL when record inherits origin

### DIFF
--- a/gozone.go
+++ b/gozone.go
@@ -943,6 +943,11 @@ func (s *Scanner) Next(outrecord *Record) error {
 			return fmt.Errorf("Record for current domain specified when no $ORIGIN defined")
 		}
 		domain = s.origin
+		// this means that the token is the TTL; this record should inherit default origin and TTL should not be appended to DomainName
+	} else if i64, err := strconv.ParseInt(token, 10, 64); err == nil {
+		domain = s.origin
+		record.TimeToLive = i64
+		hasTTL = true
 	} else if domain[len(token)-1] != '.' {
 		if s.origin == "" {
 			return fmt.Errorf("Record relative-to-current domain specified when no $ORIGIN defined")

--- a/gozone_test.go
+++ b/gozone_test.go
@@ -300,7 +300,7 @@ func TestOriginDefinesDefault(t *testing.T) {
 
 func TestOriginControlEntrySetsOrigin(t *testing.T) {
 	var r Record
-	s := NewScanner(strings.NewReader("$ORIGIN adomain.com.\n@ 300 IN A 192.168.1.1"))
+	s := NewScanner(strings.NewReader("$ORIGIN adomain.com.\n300 IN A 192.168.1.1"))
 
 	err := s.Next(&r)
 	if err != nil {
@@ -309,6 +309,10 @@ func TestOriginControlEntrySetsOrigin(t *testing.T) {
 
 	if s.origin != "adomain.com." {
 		t.Fatalf("Parsing of $ORIGIN control entry did not set the default origin")
+	}
+
+	if r.DomainName != "adomain.com." {
+		t.Fatalf("Parsing of $ORIGIN control entry did not set the default domain name")
 	}
 }
 


### PR DESCRIPTION
Ran into an issue where, if the record was inheriting the origin, the parser would set the TTL as a subdomain and the TTL to -1 due to https://github.com/wpalmer/gozone/blob/master/gozone.go#L951

For a file like this:
```
$ORIGIN example.com.
@                      3600 SOA   ns1.p30.dynect.net. (
                              zone-admin.dyndns.com.     ; address of responsible party
                              2016072701                 ; serial number
                              3600                       ; refresh period
                              600                        ; retry period
                              604800                     ; expire time
                              1800                     ) ; minimum ttl
                    86400 NS    ns1.p30.dynect.net.
                    86400 NS    ns2.p30.dynect.net.
                    86400 NS    ns3.p30.dynect.net.
                    86400 NS    ns4.p30.dynect.net.
                     3600 MX    10 mail.example.com.
                     3600 MX    20 vpn.example.com.
                     3600 MX    30 mail.example.com.
                       60 A     204.13.248.106
                     3600 TXT   "v=spf1 includespf.dynect.net ~all"
mail                  14400 A     204.13.248.106
vpn                      60 A     216.146.45.240
webapp                   60 A     216.146.46.10
webapp                   60 A     216.146.46.11
www                   43200 CNAME example.com.
```

Output would look like this (I added some extra log lines but you can still see the issue):
```
SOA Record points to [ns1.p30.dynect.net. ( zone-admin.dyndns.com. 2016072701 3600 600 604800 1800 )] for domain/subdomain example.com. with TTL 3600
NS Record points to [ns1.p30.dynect.net.] for domain/subdomain 86400.example.com. with TTL -1
NS Record points to [ns2.p30.dynect.net.] for domain/subdomain 86400.example.com. with TTL -1
NS Record points to [ns3.p30.dynect.net.] for domain/subdomain 86400.example.com. with TTL -1
NS Record points to [ns4.p30.dynect.net.] for domain/subdomain 86400.example.com. with TTL -1
MX Record points to [10 mail.example.com.] for domain/subdomain 3600.example.com. with TTL -1
MX Record points to [20 vpn.example.com.] for domain/subdomain 3600.example.com. with TTL -1
MX Record points to [30 mail.example.com.] for domain/subdomain 3600.example.com. with TTL -1
A Record points to [204.13.248.106] for domain/subdomain 60.example.com. with TTL -1
TXT Record points to ["v=spf1 includespf.dynect.net ~all"] for domain/subdomain 3600.example.com. with TTL -1
A Record points to [204.13.248.106] for domain/subdomain mail.example.com. with TTL 14400
A Record points to [216.146.45.240] for domain/subdomain vpn.example.com. with TTL 60
A Record points to [216.146.46.10] for domain/subdomain webapp.example.com. with TTL 60
A Record points to [216.146.46.11] for domain/subdomain webapp.example.com. with TTL 60
CNAME Record points to [example.com.] for domain/subdomain www.example.com. with TTL 43200
```

This PR fixes by updating an existing test to check for this and adds a condition that checks if the token is the TTL.